### PR TITLE
QCamera2: fix build error

### DIFF
--- a/QCamera2/Android.mk
+++ b/QCamera2/Android.mk
@@ -50,7 +50,7 @@ LOCAL_C_INCLUDES := \
         $(LOCAL_PATH)/stack/common \
         frameworks/native/include/media/hardware \
         frameworks/native/include/media/openmax \
-        hardware/qcom/media/libstagefrighthw \
+        hardware/qcom/media/default/libstagefrighthw \
         system/media/camera/include \
         $(LOCAL_PATH)/../mm-image-codec/qexif \
         $(LOCAL_PATH)/../mm-image-codec/qomx_core \


### PR DESCRIPTION
http://hastebin.com/wudaguvomo.mel
Fixes that missing header for Nexus 5X [bullhead]
